### PR TITLE
Changes required to make the code compatible with Mac OSX

### DIFF
--- a/runtime/source/common.c
+++ b/runtime/source/common.c
@@ -85,7 +85,7 @@ void COMPrint(char *format,...) {
  * @param      s     string to write.
  */
 void COMWrite(char *s) {
-    printf(s);
+    printf("%s",s);
 }
 
 /**

--- a/runtime/source/fileio/directory.c
+++ b/runtime/source/fileio/directory.c
@@ -51,6 +51,7 @@ int32_t FSReadDirectory(int32_t handle,FSOBJECTINFO *fso) {
     DIR **ppDir;
     int32_t err = FSGetValidateHandle(handle,true,(void **)&ppDir);                 // Validate the handle and get the directory object.
     if (err != 0) return err;
+    errno = 0;                                                                      // reset errno before readdir
     struct dirent *next = readdir(*ppDir);                                          // Read next entry.
     if (next == NULL) {                                                             // Read failed.
         if (errno == 0 || errno == EAGAIN) return FSERR_EOF;                        // End of directory

--- a/runtime/source/fileio/filesupport.c
+++ b/runtime/source/fileio/filesupport.c
@@ -87,9 +87,10 @@ bool FSProcessFileName(char **pFileName) {
     char *p;
     strcpy(buffer,"storage/");                                                      // Append full file name to storage
     strcat(buffer,FSCDMapCurrentName(*pFileName));
-    while (p = strstr(buffer,"//"),p != NULL) {                                     // Remove any double slashes. Don't think Linux minds
-        strcpy(p,p+1);                                                              // but Windows uses it as a server marker ?
+    while ((p = strstr(buffer, "//")) != NULL) {                                    // Remove any double slashes. Don't think Linux minds
+        memmove(p, p + 1, strlen(p));                                               // but Windows uses it as a server marker ? memmove is more safety then strcpy on overlap. Max OSx
     }
+
     #if BACKSLASH==1                                                                // Make windows slashes correct. 
     p = buffer;
     while (*p != '\0') {


### PR DESCRIPTION
Code:
```
void COMWrite(char *s) {
	printf(s);
`}`
```
Clang on macOS considers it unsafe, and GCC could also raise the same error if compiled with the `-Wformat-security`option.
To make it compatible, it should be replaced with:
    
```
    void COMWrite(char *s) {
        printf("%s", s);
    }
```

The code
```
while (p = strstr(buffer,"//"), p != NULL) {
    strcpy(p, p+1);
}
```
produces on macOS a
**Trace/BPT trap: 5**, which usually indicates a memory error — invalid access or illegal write.
The following code fixes the problem:
```
while ((p = strstr(buffer, "//")) != NULL) {
    memmove(p, p + 1, strlen(p));  // memmove is safer than strcpy on overlap
}
```

On macOS systems it’s better to reset
`errno = 0;  // reset errno before readdir`
before the call
`next = readdir(*ppDir);`

I think these changes work also on Linux. I can't try because I haven't a Linux PC.
    